### PR TITLE
CtrlP custom modes

### DIFF
--- a/autoload/hopper.vim
+++ b/autoload/hopper.vim
@@ -337,6 +337,30 @@ function! s:load_speed()
 endfunction
 
 
+""""""""""""""""""""""
+"  CtrlPCustomModes  "
+""""""""""""""""""""""
+
+function! s:load_ctrlp_custom_modes()
+  if !exists('g:loaded_ctrlp_custom_modes')
+    return
+  endif
+
+  let mode = 'ctrlp-custom'
+  let enter_key = 'p'
+  let cmds = ['p', 'o']
+  let mappings = {}
+
+  let i = 0
+  for cmd in cmds
+    let mappings[cmd] = ':CtrlPCustomMode'.i.'<cr>'
+    let i += 1
+  endfor
+
+  call hopper#create_mode(mode, 'n', '', enter_key, mappings)
+endfunction
+
+
 """"""""""""""
 "  yankring  "
 """"""""""""""

--- a/autoload/hopper.vim
+++ b/autoload/hopper.vim
@@ -348,7 +348,7 @@ function! s:load_ctrlp_custom_modes()
 
   let mode = 'ctrlp-custom'
   let enter_key = 'p'
-  let cmds = ['p', 'o']
+  let cmds = ['j', 'f', 'k', 'd', 'l', 's', "'", 'a', 'h', 'g']
   let mappings = {}
 
   let i = 0

--- a/plugin/hopper.vim
+++ b/plugin/hopper.vim
@@ -16,7 +16,7 @@ endif
 if !exists('g:hopper_support_modes')
   let g:hopper_support_modes = [
         \'buffer', 'exchange', 'gitgutter', 'location', 'quickfix',
-        \'speed', 'tab', 'tag', 'yankring', 'window'
+        \'speed', 'tab', 'tag', 'yankring', 'window', 'ctrlp_custom_modes'
         \]
 endif
 


### PR DESCRIPTION
Add submode mappings for [ctrlp_custom_modes](https://github.com/LFDM/ctrlp_custom_modes)

This is not a typicaly hopper mode, as there is really no movement involved. Every command of this submode is just a one-off. Still handy to avoid pollution of other keybindings.
